### PR TITLE
Add republish project functionality with validation and permissions

### DIFF
--- a/dev-ops/integration_test.self_creation_portal.env
+++ b/dev-ops/integration_test.self_creation_portal.env
@@ -211,10 +211,11 @@ AUTH_TOKEN_HEADER_NAME='x-auth-token'
 ORG_ID_HEADER_NAME='organization-id'
 # HTTP header for tenant ID
 TENANT_ID_HEADER_NAME='tenant-id'
-# Default organization code
-DEFAULT_ORGANISATION_CODE='default_code'
+
 # Default tenant code
 DEFAULT_TENANT_CODE='default'
+# Default organization code
+DEFAULT_ORGANIZATION_CODE='default_code
 # Auth config file path
 AUTH_CONFIG_FILE_PATH='config.json'
 

--- a/dev-ops/integration_test.self_creation_portal.env
+++ b/dev-ops/integration_test.self_creation_portal.env
@@ -215,7 +215,7 @@ TENANT_ID_HEADER_NAME='tenant-id'
 # Default tenant code
 DEFAULT_TENANT_CODE='default'
 # Default organization code
-DEFAULT_ORGANIZATION_CODE='default_code
+DEFAULT_ORGANIZATION_CODE='default_code'
 # Auth config file path
 AUTH_CONFIG_FILE_PATH='config.json'
 

--- a/src/api-doc/Self Creation Portal.postman_collection.json
+++ b/src/api-doc/Self Creation Portal.postman_collection.json
@@ -1232,6 +1232,30 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Republish Project",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "X-auth-token",
+								"value": "bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{SCPBaseUrl}}scp/v1/projects/republish/:id",
+							"host": ["{{SCPBaseUrl}}scp"],
+							"path": ["v1", "projects", "republish", ":id"],
+							"variable": [
+								{
+									"key": "id",
+									"value": ""
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},

--- a/src/api-doc/api-doc.yaml
+++ b/src/api-doc/api-doc.yaml
@@ -3288,7 +3288,7 @@ paths:
                 example1:
                   value:
                     responseCode: OK
-                    message: PROJECT_REPUBLISHED
+                    message: Project republished successfully.
                     result:
                       id: 1
                     meta:

--- a/src/api-doc/api-doc.yaml
+++ b/src/api-doc/api-doc.yaml
@@ -3229,6 +3229,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/deleteProject400Response'
+  '/scp/v1/projects/republish/{projectId}':
+    post:
+      summary: Republish Project
+      tags:
+        - Projects
+      description: |-
+        Use this API to republish a project that has already been published.
+        - The API endpoint for republishing a project is `/scp/v1/projects/republish/{projectId}`.
+        - It is mandatory to provide values for parameters marked as `required`.
+        - The `projectId` parameter is mandatory and cannot be empty or null.
+      parameters:
+        - name: X-auth-token
+          in: header
+          description: The `X-auth-token` is required to use this API. It is available in the login API response.
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: projectId
+          description: A valid project ID must be appended to the request URL.
+          schema:
+            type: integer
+          required: true
+          example: 1
+      responses:
+        '200':
+          description: Project republished successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  responseCode:
+                    type: string
+                  message:
+                    type: string
+                  result:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                  meta:
+                    type: object
+                    properties:
+                      formsVersion:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                            type:
+                              type: string
+                            version:
+                              type: integer
+              examples:
+                example1:
+                  value:
+                    responseCode: OK
+                    message: PROJECT_REPUBLISHED
+                    result:
+                      id: 1
+                    meta:
+                      formsVersion:
+                        - id: 3
+                          type: projectCreation
+                          version: 3
+        '400':
+          description: Bad Request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/deleteProject400Response'
   '/scp/v1/projects/details/{projectId}':
     post:
       summary: Project Details

--- a/src/constants/interface-routes/elevate-scp/configs.json
+++ b/src/constants/interface-routes/elevate-scp/configs.json
@@ -313,6 +313,19 @@
 			]
 		},
 		{
+			"sourceRoute": "/scp/v1/projects/republish/:id",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "self-creation-portal",
+					"packageName": "elevate-self-creation-portal"
+				}
+			]
+		},
+		{
 			"sourceRoute": "/scp/v1/projects/update",
 			"type": "POST",
 			"priority": "MUST_HAVE",

--- a/src/consumption/elevate.js
+++ b/src/consumption/elevate.js
@@ -8,7 +8,6 @@ const MongoDBConnection = require('@configs/mongoConnection')
 const resourceService = require('@services/resource')
 const rolloutService = require('@services/rollouts')
 const targetingHelpers = require('@helpers/targetingCriteria')
-const entityModelMappingQuery = require('@database/queries/entityModelMapping')
 const { Op } = require('sequelize')
 const requests = require('@generics/requests')
 const responseCode = require('@generics/http-status')
@@ -645,12 +644,14 @@ const publishProjectTemplates = function (templateData) {
 				projectsMongoConnection
 			)
 
+			// Set visibility based on org policies
+			template.visibility = common.ORG_POLICY_CURRENT
+			template.visibleToOrganizations = [templateData.organization_code]
+
+			// Override visibility if org policies are successfully fetched
 			if (orgPolicies.success) {
 				template.visibility = orgPolicies.policies.visibility
 				template.visibleToOrganizations = orgPolicies.policies.visibleToOrganizations
-			} else {
-				template.policies.visibility = ''
-				template.policies.visibleToOrganizations = []
 			}
 
 			// Process Categories
@@ -719,8 +720,10 @@ const publishProjectTemplates = function (templateData) {
 			//return result
 			result.success = true
 			result.templateId = templateId
+			console.log('Template published successfully with ID:', templateId)
 			return resolve(result)
 		} catch (error) {
+			console.log('Error in publishProjectTemplates:', error.message)
 			if (mongoConnection) mongoConnection.disconnect()
 			result.error = error.message || error
 			return reject(error)

--- a/src/controllers/v1/projects.js
+++ b/src/controllers/v1/projects.js
@@ -112,4 +112,21 @@ module.exports = class Projects {
 			return error
 		}
 	}
+
+	/**
+	 * republish project
+	 * @method
+	 * @name republish
+	 * @param {Object} req - request data.
+	 * @returns {JSON} - project republish response.
+	 */
+
+	async republish(req) {
+		try {
+			const republish = await projectService.republish(req.params.id, req.decodedToken)
+			return republish
+		} catch (error) {
+			return error
+		}
+	}
 }

--- a/src/controllers/v1/projects.js
+++ b/src/controllers/v1/projects.js
@@ -123,8 +123,8 @@ module.exports = class Projects {
 
 	async republish(req) {
 		try {
-			const republish = await projectService.republish(req.params.id, req.decodedToken)
-			return republish
+			const response = await projectService.republish(parseInt(req.params.id), req.decodedToken)
+			return response
 		} catch (error) {
 			return error
 		}

--- a/src/database/migrations/20251031132957-add-permissions-for-projects-republish.js
+++ b/src/database/migrations/20251031132957-add-permissions-for-projects-republish.js
@@ -1,0 +1,84 @@
+'use strict'
+
+require('module-alias/register')
+require('dotenv').config()
+const Permissions = require('@database/models/index').Permission
+
+const getPermissionId = async (module, request_type, api_path) => {
+	let permission = await Permissions.findOne({
+		where: { module, request_type, api_path },
+	})
+
+	if (!permission) {
+		permission = await createPermission(
+			'projects',
+			['POST'],
+			'/scp/v1/projects/republish*',
+			'projects_republish_permissions'
+		)
+	}
+	return permission.id
+}
+
+const createPermission = async (module, request_type, api_path, code) => {
+	const now = new Date()
+	const permission = await Permissions.create({
+		module,
+		request_type,
+		api_path,
+		code,
+		createdAt: now,
+		updatedAt: now,
+	})
+	return permission
+}
+
+module.exports = {
+	async up(queryInterface, Sequelize) {
+		let permission_id = await getPermissionId('projects', ['POST'], '/scp/v1/projects/republish*')
+
+		let defaultContentCreatorRoles = process.env.DEFAULT_CONTENT_CREATOR_ROLE
+			? process.env.DEFAULT_CONTENT_CREATOR_ROLE.split(',')
+			: []
+		let defaultReviewerRoles = process.env.DEFAULT_REVIEWER_ROLE ? process.env.DEFAULT_REVIEWER_ROLE.split(',') : []
+
+		const rolePermissionsData = []
+
+		// Add permissions for content creator roles
+		defaultContentCreatorRoles.forEach((role) => {
+			rolePermissionsData.push({
+				role_title: role.trim(),
+				permission_id,
+				module: 'projects',
+				request_type: ['POST'],
+				api_path: '/scp/v1/projects/republish*',
+				created_at: new Date(),
+				updated_at: new Date(),
+				created_by: 0,
+			})
+		})
+
+		// Add permissions for reviewer roles
+		defaultReviewerRoles.forEach((role) => {
+			rolePermissionsData.push({
+				role_title: role.trim(),
+				permission_id,
+				module: 'projects',
+				request_type: ['POST'],
+				api_path: '/scp/v1/projects/republish/:id',
+				created_at: new Date(),
+				updated_at: new Date(),
+				created_by: 0,
+			})
+		})
+
+		if (rolePermissionsData.length > 0) {
+			await queryInterface.bulkInsert('role_permission_mapping', rolePermissionsData)
+		}
+	},
+
+	async down(queryInterface, Sequelize) {
+		await queryInterface.bulkDelete('role_permission_mapping', { api_path: '/scp/v1/projects/republish*' }, {})
+		await queryInterface.bulkDelete('permissions', { code: 'projects_republish_permissions' }, {})
+	},
+}

--- a/src/database/migrations/20251031132957-add-permissions-for-projects-republish.js
+++ b/src/database/migrations/20251031132957-add-permissions-for-projects-republish.js
@@ -65,7 +65,7 @@ module.exports = {
 				permission_id,
 				module: 'projects',
 				request_type: ['POST'],
-				api_path: '/scp/v1/projects/republish/:id',
+				api_path: '/scp/v1/projects/republish*',
 				created_at: new Date(),
 				updated_at: new Date(),
 				created_by: 0,

--- a/src/integration-tests/projects/projects.spec.js
+++ b/src/integration-tests/projects/projects.spec.js
@@ -64,14 +64,11 @@ describe('Project APIs ', function () {
 			'/scp/v1/resource/getPublishedResources?page=1&limit=5&type=project'
 		)
 		const projectId = publishedProjectsRes?.body?.result?.data?.[0]?.id
+		expect(projectId).toBeDefined()
 
-		if (projectId) {
-			const res = await request.post(`/scp/v1/projects/republish/${projectId}`)
-			expect(res.statusCode).toBe(200)
-			expect(res.body).toMatchSchema(schema.republishProjectSchema)
-		} else {
-			console.log('No published projects found for republish test')
-		}
+		const res = await request.post(`/scp/v1/projects/republish/${projectId}`)
+		expect(res.statusCode).toBe(200)
+		expect(res.body).toMatchSchema(schema.republishProjectSchema)
 	})
 
 	it('List Project with data', async () => {

--- a/src/integration-tests/projects/projects.spec.js
+++ b/src/integration-tests/projects/projects.spec.js
@@ -53,6 +53,27 @@ describe('Project APIs ', function () {
 		expect(res.body).toMatchSchema(schema.reviewerListSchema)
 	})
 
+	it('Republish Project with invalid project id', async () => {
+		const res = await request.post('/scp/v1/projects/republish/9999')
+		expect(res.statusCode).toBe(400)
+	})
+
+	it('Republish Project with valid published project id', async () => {
+		// Get a published project
+		const publishedProjectsRes = await request.get(
+			'/scp/v1/resource/getPublishedResources?page=1&limit=5&type=project'
+		)
+		const projectId = publishedProjectsRes?.body?.result?.data?.[0]?.id
+
+		if (projectId) {
+			const res = await request.post(`/scp/v1/projects/republish/${projectId}`)
+			expect(res.statusCode).toBe(200)
+			expect(res.body).toMatchSchema(schema.republishProjectSchema)
+		} else {
+			console.log('No published projects found for republish test')
+		}
+	})
+
 	it('List Project with data', async () => {
 		//create project
 		let createProject = await request.post('/scp/v1/projects/update').send(insertProjectData())

--- a/src/integration-tests/projects/responseSchema.js
+++ b/src/integration-tests/projects/responseSchema.js
@@ -635,6 +635,53 @@ const reviewerListSchema = {
 	required: ['responseCode', 'message', 'result'],
 }
 
+const republishProjectSchema = {
+	type: 'object',
+	properties: {
+		responseCode: {
+			type: 'string',
+		},
+		message: {
+			type: 'string',
+		},
+		result: {
+			type: 'object',
+			properties: {
+				id: {
+					type: 'integer',
+				},
+			},
+			required: ['id'],
+		},
+		meta: {
+			type: 'object',
+			properties: {
+				formsVersion: {
+					oneOf: [
+						{
+							type: 'object',
+							properties: {},
+							additionalProperties: true,
+						},
+						{
+							type: 'array',
+							items: {
+								type: 'object',
+								properties: {},
+								additionalProperties: true,
+							},
+						},
+					],
+				},
+				correlation: {
+					type: 'string',
+				},
+			},
+		},
+	},
+	required: ['responseCode', 'message', 'result', 'meta'],
+}
+
 module.exports = {
 	createSchema,
 	detailSchema,
@@ -642,4 +689,5 @@ module.exports = {
 	emptyListSchema,
 	submitProjectSchema,
 	reviewerListSchema,
+	republishProjectSchema,
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -176,5 +176,9 @@
 	"CONSUMPTION_LINK_FETCH_FAILED": "Consumption link fetch failed",
 	"CONSUMPTION_LINK_FETCHED": "Link fetched successfully",
 	"ENTITY_TYPE_FETCHED_SUCCESSFULLY": "Entity types fetched successfully",
-	"FAILED_TO_FETCH_ENTITY_TYPES": "Failed to fetch entity types"
+	"FAILED_TO_FETCH_ENTITY_TYPES": "Failed to fetch entity types",
+	"CANNOT_REPUBLISH_UNPUBLISHED_PROJECT": "This project cannot be republished as it has not been published yet.",
+	"PROJECT_ALREADY_PUBLISHED": "This project has already been published. No need to republish.",
+	"PROJECT_REPUBLISHED_SUCCESSFULLY": "Project republished successfully.",
+	"PROJECT_REPUBLISH_FAILED": "Project republish failed."
 }

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -876,60 +876,63 @@ module.exports = class ProjectsHelper {
 	 */
 	static async republish(projectId, userDetails) {
 		try {
-			let projectDetails = await this.details(projectId, userDetails.organization_code, userDetails.tenant_code)
-			if (projectDetails.statusCode !== httpStatusCode.ok) {
-				return responses.failureResponse({
+			// Fetch project details with authorization check
+			const projectDetailsResponse = await this.details(
+				projectId,
+				userDetails.organization_code,
+				userDetails.tenant_code
+			)
+
+			if (projectDetailsResponse.statusCode !== httpStatusCode.ok) {
+				throw {
 					message: 'DONT_HAVE_PROJECT_ACCESS',
 					statusCode: httpStatusCode.bad_request,
-					responseCode: 'CLIENT_ERROR',
-				})
+				}
 			}
-			let projectData = projectDetails.result
+			const projectData = projectDetailsResponse.result
 
-			// check if project status is PUBLISHED
+			// Validate project status is PUBLISHED
 			if (projectData.status !== common.RESOURCE_STATUS_PUBLISHED) {
-				return responses.failureResponse({
-					message: 'PROJECT_NOT_PUBLISHED',
+				throw {
+					message: 'CANNOT_REPUBLISH_UNPUBLISHED_PROJECT',
 					statusCode: httpStatusCode.bad_request,
-					responseCode: 'CLIENT_ERROR',
-				})
+				}
 			}
 
+			// Validate project has not been already published
 			if (projectData.published_id) {
-				return responses.failureResponse({
-					message: 'PROJECT_ALREADY_REPUBLISHED',
+				throw {
+					message: 'PROJECT_ALREADY_PUBLISHED',
 					statusCode: httpStatusCode.bad_request,
-					responseCode: 'CLIENT_ERROR',
-				})
+				}
 			}
 
-			// republish project
-			const republishResource = await reviewService.publishResource(
+			// Initiate republish process
+			const republishResponse = await reviewService.publishResource(
 				projectId,
 				projectData.user_id,
 				projectData.organization_code,
-				projectData.tenant_code
+				projectData.tenant_code,
+				userDetails.token
 			)
 
-			if (![httpStatusCode.ok, httpStatusCode.accepted].includes(republishResource.statusCode)) {
-				return responses.failureResponse({
-					message: `Project republish failed: ${republishResource.message || 'Unknown error'}`,
+			if (![httpStatusCode.ok, httpStatusCode.accepted].includes(republishResponse.statusCode)) {
+				throw {
+					message: republishResponse.message || 'PROJECT_REPUBLISH_FAILED',
 					statusCode: httpStatusCode.bad_request,
-					responseCode: 'CLIENT_ERROR',
-				})
+				}
 			}
 
 			return responses.successResponse({
 				statusCode: httpStatusCode.ok,
-				message: 'PROJECT_REPUBLISHED',
+				message: 'PROJECT_REPUBLISHED_SUCCESSFULLY',
 				result: { id: projectData.id },
 			})
 		} catch (error) {
 			return responses.failureResponse({
 				message: error.message || 'RESOURCE_VALIDATION_FAILED',
-				statusCode: httpStatusCode.internal_server_error,
+				statusCode: error.statusCode || httpStatusCode.internal_server_error,
 				responseCode: 'CLIENT_ERROR',
-				result: error.error || [],
 			})
 		}
 	}

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -867,6 +867,74 @@ module.exports = class ProjectsHelper {
 	}
 
 	/**
+	 * Project republish
+	 * @method
+	 * @name republish
+	 * @param {Integer} projectId - Project Id.
+	 * @param {Object} userDetails - User details
+	 * @returns {JSON} - project republish response.
+	 */
+	static async republish(projectId, userDetails) {
+		try {
+			let projectDetails = await this.details(projectId, userDetails.organization_code, userDetails.tenant_code)
+			if (projectDetails.statusCode !== httpStatusCode.ok) {
+				return responses.failureResponse({
+					message: 'DONT_HAVE_PROJECT_ACCESS',
+					statusCode: httpStatusCode.bad_request,
+					responseCode: 'CLIENT_ERROR',
+				})
+			}
+			let projectData = projectDetails.result
+
+			// check if project status is PUBLISHED
+			if (projectData.status !== common.RESOURCE_STATUS_PUBLISHED) {
+				return responses.failureResponse({
+					message: 'PROJECT_NOT_PUBLISHED',
+					statusCode: httpStatusCode.bad_request,
+					responseCode: 'CLIENT_ERROR',
+				})
+			}
+
+			if (projectData.published_id) {
+				return responses.failureResponse({
+					message: 'PROJECT_ALREADY_REPUBLISHED',
+					statusCode: httpStatusCode.bad_request,
+					responseCode: 'CLIENT_ERROR',
+				})
+			}
+
+			// republish project
+			const republishResource = await reviewService.publishResource(
+				projectId,
+				projectData.user_id,
+				projectData.organization_code,
+				projectData.tenant_code
+			)
+
+			if (![httpStatusCode.ok, httpStatusCode.accepted].includes(republishResource.statusCode)) {
+				return responses.failureResponse({
+					message: `Project republish failed: ${republishResource.message || 'Unknown error'}`,
+					statusCode: httpStatusCode.bad_request,
+					responseCode: 'CLIENT_ERROR',
+				})
+			}
+
+			return responses.successResponse({
+				statusCode: httpStatusCode.ok,
+				message: 'PROJECT_REPUBLISHED',
+				result: { id: projectData.id },
+			})
+		} catch (error) {
+			return responses.failureResponse({
+				message: error.message || 'RESOURCE_VALIDATION_FAILED',
+				statusCode: httpStatusCode.internal_server_error,
+				responseCode: 'CLIENT_ERROR',
+				result: error.error || [],
+			})
+		}
+	}
+
+	/**
 	 * Validates the given project data
 	 * @method
 	 * @name validateEntityData

--- a/src/services/rollouts.js
+++ b/src/services/rollouts.js
@@ -849,7 +849,7 @@ module.exports = class RolloutsHelper {
 				organization_code: org_code,
 				type: common.ROLL_OUT,
 				userToken,
-				userId: loggedInUserId,
+				userId: rolloutDetailsResult.user_id,
 			}
 
 			if (process.env.CONSUMPTION_SERVICE != common.SELF) {

--- a/src/validators/v1/projects.js
+++ b/src/validators/v1/projects.js
@@ -79,4 +79,14 @@ module.exports = {
 			.notEmpty()
 			.withMessage('reviewer_ids is empty')
 	},
+	republish: (req) => {
+		req.checkParams('id')
+			.trim()
+			.notEmpty()
+			.withMessage('id param is empty')
+			.isNumeric()
+			.withMessage('id param is invalid, must be an integer')
+			.isInt({ min: 1, max: 2147483647 })
+			.withMessage('Id is not valid')
+	},
 }


### PR DESCRIPTION
- Implemented API endpoint for republishing projects.
- Added validation for project ID in the request.
- Created response schema for republish project API.
- Updated service and controller to handle republish logic.
- Added integration tests for republish functionality.
- Included necessary permissions in the database migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can republish previously published projects via a new republish action.

* **Validation**
  * Republish requests enforce trimmed, numeric IDs with integer range checks.

* **Tests**
  * Integration tests and response schema cover republish success and error cases.

* **Chore**
  * Permissions and route configuration added for the republish endpoint.

* **Behavior Change**
  * Published rollout messages now use a different user identifier in downstream payloads.

* **Localization**
  * Added messages for republish success, failure, and validation states.

* **Logging**
  * Extra logs around template publication and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->