### PR TITLE
fix: remove source_resource_id for non-reusable original resources in…

### DIFF
--- a/src/services/programs.js
+++ b/src/services/programs.js
@@ -1610,6 +1610,9 @@ async function handleResources(
 						if (isReusable) {
 							// mark the original reusable resource this copy came from
 							duplicatedResourceData.source_resource_id = resourceDetails.id
+						} else {
+							// do not carry forward source linkage for non-reusable originals
+							delete duplicatedResourceData.source_resource_id
 						}
 						delete duplicatedResourceData.id // Remove the ID to create a new resource
 


### PR DESCRIPTION
… handleResources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource duplication behavior to properly handle source linkage. Non-reusable resources no longer retain unnecessary connections when duplicated, while reusable resources maintain proper source references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->